### PR TITLE
ci: support brand names with hyphens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
               BUILD=true
             fi
 
-            echo "build_${APP}=${BUILD}" >> "$GITHUB_OUTPUT"
+            echo "build_${APP//-/_}=${BUILD}" >> "$GITHUB_OUTPUT"
           done
 
       - name: Clear older runs


### PR DESCRIPTION
Add support for brand names containing hyphens in the CI workflow. This ensures that brands with dashes (like rookie-enough or hoo-dles) are correctly recognized and built