### PR TITLE
feat: add direct download links to release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,10 +172,12 @@ jobs:
       - name: Combine logs
         if: steps.check_artifacts.outputs.has_artifacts == 'true'
         id: get_output
+        env:
+          TAG: ${{ steps.version.outputs.version }}
         run: |
           DELIM="$(openssl rand -hex 8)"
           echo "BUILD_LOG<<${DELIM}" >> "$GITHUB_OUTPUT"
-          uv run main.py combine-logs logs >> "$GITHUB_OUTPUT"
+          uv run main.py combine-logs logs | sed "s/{TAG}/$TAG/g" >> "$GITHUB_OUTPUT"
           echo "${DELIM}" >> "$GITHUB_OUTPUT"
 
       - name: Upload release

--- a/src/core/builder.py
+++ b/src/core/builder.py
@@ -144,7 +144,9 @@ def _build_single(entry: AppEntry, arch: str, label: str, net: NetworkManager, p
         _verify_sig(stock_apk, stock_apkm, pkg_name, patcher, label)
         apk_output = _apply_patch(entry, arch, version, force, patcher, list_patches, stock_apk, stock_apkm)
         pr(f"Built {label}: '{apk_output}'")
-        return f"🟢 » {label}: `{version}`"
+        if os.getenv("GITHUB_ACTIONS") == "true":
+            return f"- 🟢 » {label}: [`{version}`](../../releases/download/{{TAG}}/{apk_output.name})"
+        return f"- 🟢 » {label}: `{version}`"
     except (BuilderError, PatcherError, ValueError, Exception) as exc:
         epr(f"Building '{label}' failed! {exc}")
         return None
@@ -214,6 +216,6 @@ def run_build(data: dict[str, object], config: Config, net: NetworkManager, targ
         return False
 
     changelogs = "".join(cl.read_text(encoding="utf-8") for cl in sorted(TEMP_DIR.glob("*/changelog.md")))
-    Path("build.md").write_text("\n".join([*log_lines, "", "- ▶️ » Install [MicroG-RE](https://github.com/MorpheApp/MicroG-RE/releases) for YouTube and YT Music APKs\n", changelogs]), encoding="utf-8")
+    Path("build.md").write_text("\n".join([*log_lines, "", "▶️ » Install [MicroG-RE](https://github.com/MorpheApp/MicroG-RE/releases) for YouTube and YT Music APKs\n", changelogs]), encoding="utf-8")
     pr("Done")
     return True

--- a/src/core/gh_utils.py
+++ b/src/core/gh_utils.py
@@ -46,9 +46,9 @@ def combine_logs(logs_dir: Path | str) -> None:
             line = raw.strip()
             if not line:
                 continue
-            if line.startswith("🟢"):
+            if line.startswith("- 🟢"):
                 green_lines.append(f"{line}  ")
-            elif not microg_line and line.startswith("-") and "MicroG" in line:
+            elif not microg_line and line.startswith("▶️") and "MicroG" in line:
                 microg_line = line
             if _RE_CLI_START.match(line):
                 capturing = True


### PR DESCRIPTION
Finding specific files in the release section can be difficult when there are many artifacts or when long filenames obscure architecture details
This PR:
- Adds direct download links for each APK within the release notes
- Switched to a bulleted list format to increase the vertical spacing between links and prevent accidental clicks

<img width="481" height="989" alt="image" src="https://github.com/user-attachments/assets/b831117c-45b4-492d-bfb4-03d49fa27fbf" />
<img width="1156" height="478" alt="image" src="https://github.com/user-attachments/assets/ab38cd8b-5b33-4a6d-842c-7d68c7a7c9f7" />

