### PR TITLE
ci: skip changelog filter on manual or force builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ on:
       patch_source:
         default: 'morphe'
         type: string
+      filter_changelog:
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -59,6 +62,7 @@ jobs:
       - name: Set matrix based on patch source
         id: set-matrix
         env:
+          FILTER_CHANGELOG: ${{ inputs.filter_changelog }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "matrix=$(uv run python -m src.scripts.matrix get-matrix '${{ inputs.patch_source }}')" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       patch_source: 'morphe'
+      filter_changelog: ${{ inputs.force_build != true }}
     secrets: inherit
 
   build-piko:
@@ -65,4 +66,5 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       patch_source: 'piko'
+      filter_changelog: ${{ inputs.force_build != true }}
     secrets: inherit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,7 @@ build-<brand>:
   uses: ./.github/workflows/build.yml
   with:
     patch_source: '<brand>'
+    filter_changelog: ${{ inputs.force_build != true }}
   secrets: inherit
 ```
 

--- a/src/scripts/matrix.py
+++ b/src/scripts/matrix.py
@@ -44,6 +44,7 @@ def get_matrix(source: str) -> None:
     data = load_toml(CONFIG_PATH)
     main_cfg = parse_config(data)
     source_lower = source.lower()
+    filter_changelog = os.getenv("FILTER_CHANGELOG", "false").lower() == "true"
     patches_source = ""
     has_changelog_keywords = False
     for entry in parse_app_entries(data, main_cfg):
@@ -54,7 +55,7 @@ def get_matrix(source: str) -> None:
                 break
 
     changelog_text = ""
-    if has_changelog_keywords and patches_source:
+    if filter_changelog and has_changelog_keywords and patches_source:
         with NetworkManager() as net:
             repo = os.getenv("GITHUB_REPOSITORY")
             if repo:
@@ -71,7 +72,7 @@ def get_matrix(source: str) -> None:
         if not entry.enabled or entry.brand.lower() != source_lower:
             continue
 
-        if entry.changelog_keywords and changelog_text and not any(kw in changelog_text.lower() for kw in entry.changelog_keywords):
+        if filter_changelog and entry.changelog_keywords and changelog_text and not any(kw in changelog_text.lower() for kw in entry.changelog_keywords):
             continue
 
         if entry.arch == "both":


### PR DESCRIPTION
## Description

This PR disables the changelog filter when triggering builds manually or forcing builds for all apps, ensuring that the changelog filtering feature works as intended - only running during normal CI workflows. This allows newly added apps to be built manually without being affected by the changelog filter

## Additional Context

https://github.com/nvbangg/uni-apks/actions/runs/27526933607

## Checklist

- [x] I have manually reviewed every line of my changes and take responsibility for them.
- [x] I have tested the build locally with `uv run main.py` and confirmed it works as expected.
- [x] My `config.toml` changes are valid (if applicable).