### PR TITLE
fix: Telegram message length handling

### DIFF
--- a/src/scripts/telegram.py
+++ b/src/scripts/telegram.py
@@ -53,7 +53,7 @@ def notify(brand: str, final_md_path: str = "final.md") -> None:
         epr("No build results found in final.md, skipping notification")
         return
 
-    msg = _build_message(brand, green_lines, microg_line, changelog_line)[:4096]
+    msg = _build_message(brand, green_lines, microg_line, changelog_line)
     url = f"https://api.telegram.org/bot{token}/sendMessage"
     payload = {"chat_id": chat, "text": msg, "parse_mode": "Markdown", "link_preview_options": {"is_disabled": True}}
     pr(f"Sending Telegram notification for '{brand}' to '{chat}'")


### PR DESCRIPTION
## Description

This PR removes the `[:4096]` slicing logic from the Telegram notification script

Telegram's character limit does not count URL lengths, but the previous code included them, causing messages to truncate prematurely at around 25 apps (insufficient for sources like `hoo-dles` or `de-vanced`). Since calculating the exact character limit under Telegram's formatting rules is complex and error-prone, while in reality we will never reach Telegram's actual limit. Therefore, in my opinion, removing the slicing logic entirely is the best solution

## Checklist

- [x] I have manually reviewed every line of my changes and take responsibility for them.
- [x] I have tested the build locally with `uv run main.py` and confirmed it works as expected.
- [x] My `config.toml` changes are valid (if applicable).