### PR TITLE
ci: add notice for skipped builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
             echo "build_matrix=$(uv run python -m src.scripts.matrix get-matrix)" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Notify skipped build
+        if: steps.get-matrix.outputs.build_matrix == '[]'
+        run: echo "::notice title=Build Skipped::No new releases detected."
+
       - name: Clear older runs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Add a skipped build notice when no new releases are found for easier monitoring.

## Additional Context

https://github.com/nvbangg/uni-apks/actions/runs/27836973972

## Checklist

- [x] I have manually reviewed every line of my changes and take responsibility for them.
- [x] I have tested the build locally with `uv run main.py` and confirmed it works as expected.
- [x] My `config.toml` changes are valid (if applicable).