### PR TITLE
chore: use app-name as build label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ apkmirror-dlurl = "https://www.apkmirror.com/apk/inc/app"
 | `cli-version` | CLI version to fetch (`latest`, `dev`, or a specific version string) | `latest` | Global / Per-app |
 | `cli-source` | GitHub or GitLab repo for CLI (`github:owner/repo` or `gitlab:owner/repo`) | `github:MorpheApp/morphe-cli` | Global / Per-app |
 | `strict-sigcheck` | Fail the build if an app is missing from `sig.txt` (see note below) | `true` | **Global only** |
-| `app-name` | Display name used in output filename | `table name` | Per-app |
+| `app-name` | Display name used in output filename and build label | `table name` | Per-app |
 | `arch` | Target architecture (`all`, `both`, `arm64-v8a`, `armeabi-v7a`, `x86_64`, `x86`) | `all` | Per-app |
 | `version` | Target version (`auto`, `latest`, or a specific version string) | `auto` | Per-app |
 | `changelog-keywords` | List of keywords used to detect if this app was updated in the release notes | `[]` | Per-app |

--- a/src/core/builder.py
+++ b/src/core/builder.py
@@ -199,7 +199,7 @@ def _submit_entries(entries: list[AppEntry], pool: ThreadPoolExecutor, net: Netw
         patcher = PatcherCLI(cli_cache[cli_key], app_mpp_map, APKSIGNER, ks_path=ks_path)
         arches = ("arm64-v8a", "armeabi-v7a") if entry.arch == "both" else (entry.arch,)
         for arch in arches:
-            label = entry.table if entry.arch == "all" else f"{entry.table} ({arch})"
+            label = entry.app_name if entry.arch == "all" else f"{entry.app_name} ({arch})"
             futures.append(pool.submit(_build_single, entry, arch, label, net, patcher, strict_sigcheck))
     return futures
 


### PR DESCRIPTION
## Description

Use `app-name` as the build label instead of the table name for better display in release notes. For example, `YouTube Music` instead of `YouTube-Music`

## Checklist

- [x] I have manually reviewed every line of my changes and take responsibility for them.
- [x] I have tested the build locally with `uv run main.py` and confirmed it works as expected.
- [x] My `config.toml` changes are valid (if applicable).